### PR TITLE
fix permissions user_file_service

### DIFF
--- a/src/syft_rds/server/user_file_service.py
+++ b/src/syft_rds/server/user_file_service.py
@@ -4,13 +4,13 @@ from typing import Type
 from syft_rds.models.base import ItemBase
 
 USER_FILES_DIR = "user_files"
-# TODO fix permissions to only allow users to read their own folder
-USER_FILES_PERMISSION = """
+
+USER_FILES_PERMISSION_TEMPLATE = """
 rules:
 - pattern: '**'
   access:
     read:
-    - '*'
+    - '{useremail}'
 """
 
 
@@ -20,8 +20,8 @@ class UserFileService:
 
     General structure:
     USER_FILES_DIR/
-    ├── syftperm.yaml
     ├── {useremail}/
+    │   ├── syft.pub.yaml  # Read permissions for the user {useremail}
     │   ├── {item_type}/
     │   │   ├── {item_uid}/
 
@@ -46,13 +46,23 @@ class UserFileService:
         """Initialize the user files directory with proper permissions."""
         self.user_files_dir.mkdir(exist_ok=True)
 
-        perm_path = self.user_files_dir / "syft.pub.yaml"
-        perm_path.write_text(USER_FILES_PERMISSION)
+    def _is_valid_dirname(self, user: str) -> str:
+        if not user or user in {".", ".."}:
+            raise ValueError("Invalid directory name: cannot be '.' or '..' or empty")
+        disallowed = {"/", "\\", "\x00"}
+        if any(char in user for char in disallowed):
+            raise ValueError(f"Invalid directory name: contains one of {disallowed}")
+        return user
 
     def dir_for_user(self, user: str) -> Path:
         """Get the user's file directory, creating it if it doesn't exist"""
+        user = self._is_valid_dirname(user)
         user_dir = self.user_files_dir / user
         user_dir.mkdir(exist_ok=True, parents=True)
+        perm_file_path = user_dir / "syft.pub.yaml"
+        if not perm_file_path.exists():
+            with perm_file_path.open("w") as perm_file:
+                perm_file.write(USER_FILES_PERMISSION_TEMPLATE.format(useremail=user))
         return user_dir
 
     def dir_for_type(self, user: str, type_: Type[ItemBase]) -> Path:


### PR DESCRIPTION
Fix the per-user permissions for UserFileService. This means:
- Users can only see their own submitted code files
- Users can only see the results from their own job once shared

TODO:
- tests. Blocked since we don't have permissions set up for testing yet

To reproduce:
- start a syftbox server and 3 syftbox sync clients and put the config paths in top 3 variables
```
RDS_DO_CONFIG="~/.syftbox/clients/alice@rds.openmined.org/config.json"
RDS_DS_CONFIG="~/.syftbox/clients/bob@rds.openmined.org/config.json"
OTHER_USER_CONFIG="~/.syftbox/clients/charlie@rds.openmined.org/config.json"
DATA_OWNER_EMAIL = Path(RDS_DO_CONFIG).parent.name

os.environ["SYFTBOX_CLIENT_CONFIG_PATH"] = RDS_DS_CONFIG
ds_client = init_session(host=DATA_OWNER_EMAIL)

# Code created by DS exists for DS
assert ds_client.user_code.get_all()[0].local_dir.exists()

# Code created by DS does not exist for other user
other_client = init_session(host=DATA_OWNER_EMAIL, syftbox_client_config_path=OTHER_USER_CONFIG)
assert not other_client.user_code.get_all()[0].local_dir.exists()
```
